### PR TITLE
Modify drug cat alleles

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ ID | 23S1 | 23S3 | GYRA | PARC | RPOBGBS-1 | RPOBGBS-2 | RPOBGBS-3 | RPOBGBS-4
 :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---:
 25292_2#105 | 23S1 | 23S3 | GYRA | PARC-Q17S | | | | |
 
-3. **sampleID_drug_cat_alleles.txt** - Gives the alleles for drug categories: EC (macrolides, lincosamides, streptogramins or oxazolidinones), FQ (fluoroquinolones), OTHER (other antibiotics) and TET (tetracyclines)
-e.g. Isolate Step B sample 25292_2#105 have erythromycin-resistant 23S1 and 23S3, fluoroquinolone-resistant PARC and GYRA and tetracycline-resistant TETM-1 (allele of TETM)
+3. **sampleID_drug_cat_alleles_variants.txt** - Gives the GBS-specific variants and other resistance alleles for drug categories: EC (macrolides, lincosamides, streptogramins or oxazolidinones), FQ (fluoroquinolones), OTHER (other antibiotics) and TET (tetracyclines)
+e.g. Isolate Step B sample 25292_2#105 have GBS-specific variants: erythromycin-resistant 23S1 and 23S3, fluoroquinolone-resistant PARC and GYRA, and other resistance allele: tetracycline-resistant tet(M)_1
 
 ID | EC | FQ | OTHER | TET
 :---: | :---: | :---: | :---: | :---:
-25292_2#105 | 23S1:23S3 | PARC:GYRA | neg | TETM(TETM-1)
+25292_2#105 | 23S1:23S3 | PARC-Q17S:GYRA | neg | tet(M)_1
 
 #### To run on multiple samples in a directory:
 ```
 cd GBS-Typer-sanger-nf
 nextflow run main.nf --reads 'data/*_{1,2}.fastq.gz' --output 'results'
 ```
-This will produce combined tables of results_serotype_res_incidence.txt, results_gbs_res_variants.txt and results_drug_cat_alleles.txt that can be identified by sample ID (i.e. the name of the file before _1.fastq.gz or _2.fastq.gz).
+This will produce combined tables of results_serotype_res_incidence.txt, results_gbs_res_variants.txt and results_drug_cat_alleles_variants.txt that can be identified by sample ID (i.e. the name of the file before _1.fastq.gz or _2.fastq.gz).
 
 #### Additional useful options
     --restyper_min_read_depth   Minimum read depth where mappings to antibiotic resistance genes with fewer reads are excluded. (Default: 30)

--- a/bin/combine_results.py
+++ b/bin/combine_results.py
@@ -83,7 +83,7 @@ def main():
 
     # Add ID to alleles from resistance typing results
     res_alleles_output_lines = get_content_with_id(args.id, args.alleles)
-    write_output(res_alleles_output_lines, args.output + "_id_alleles.txt")
+    write_output(res_alleles_output_lines, args.output + "_id_alleles_variants.txt")
 
     # Add ID to variants from resistance typing results
     res_variants_output_lines = get_content_with_id(args.id, args.variants)

--- a/bin/process_res_typer_results.py
+++ b/bin/process_res_typer_results.py
@@ -206,21 +206,9 @@ def six_frame_translate(seq_input, frame):
     return extract_frame_aa(dna, frame)
 
 
-def update_presence_absence_target(gene, allele, depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict):
-    """Update presence/absence for GBS and Other Resistance Targets dictionary"""
+def update_presence_absence_target(gene, allele, depth, gbs_res_target_dict):
+    """Update presence/absence for GBS Targets dictionary"""
     if depth >= MIN_DEPTH:
-
-        for gene_name in res_target_dict.keys():
-            if re.search(gene_name, allele):
-                drugCat = geneToClass[gene_name]
-
-                if drug_res_col_dict[drugCat] == "neg":
-                    drug_res_col_dict[drugCat] = gene + '(' + allele + ')'
-                else:
-                    new_val = drug_res_col_dict[drugCat] + ":" + gene + '(' + allele + ')'
-                    drug_res_col_dict[drugCat] = new_val
-
-                res_target_dict[gene_name] = "pos"
 
         for gene_name in gbs_res_target_dict.keys():
             if re.search(gene_name, allele):
@@ -241,7 +229,7 @@ def derive_presence_absence_targets(input_file):
                 gene = fields[2]
                 allele = fields[3]
                 depth = float(fields[5])
-                update_presence_absence_target(gene, allele, depth, drugRes_Col, Res_Targets, GBS_Res_Targets)
+                update_presence_absence_target(gene, allele, depth, GBS_Res_Targets)
     except IOError:
         print('Cannot open {}.'.format(input_file))
 
@@ -254,14 +242,15 @@ def update_presence_absence_target_for_arg_res(gene, allele, depth, drug_res_col
         for gene_name in res_target_dict.keys():
             if re.search(gene_name, "".join(re.split("[^a-zA-Z0-9]*", allele)).upper()):
                 other = 0
-                drugCat = geneToClass[gene_name]
-                if res_target_dict[gene_name] == "neg":
-                    if drug_res_col_dict[drugCat] == "neg":
-                        drug_res_col_dict[drugCat] = gene + '(' + allele + ')'
-                    else:
-                        drug_res_col_dict[drugCat] = drug_res_col_dict[drugCat] + ':' + gene + '(' + allele + ')'
 
+                if res_target_dict[gene_name] == "neg":
                     res_target_dict[gene_name] = "pos"
+
+                drugCat = geneToClass[gene_name]
+                if drug_res_col_dict[drugCat] == "neg":
+                    drug_res_col_dict[drugCat] = gene + '(' + allele + ')'
+                else:
+                    drug_res_col_dict[drugCat] = drug_res_col_dict[drugCat] + ':' + gene + '(' + allele + ')'
 
         if other:
             if drug_res_col_dict["OTHER"] == "neg":

--- a/bin/process_res_typer_results.py
+++ b/bin/process_res_typer_results.py
@@ -234,7 +234,7 @@ def derive_presence_absence_targets(input_file):
         print('Cannot open {}.'.format(input_file))
 
 
-def update_presence_absence_target_for_arg_res(gene, allele, depth, drug_res_col_dict, res_target_dict):
+def update_presence_absence_target_for_arg_res(allele, depth, drug_res_col_dict, res_target_dict):
     """Update presence/absence for Other Resistance Targets dictionary"""
     if depth >= MIN_DEPTH:
 
@@ -248,15 +248,15 @@ def update_presence_absence_target_for_arg_res(gene, allele, depth, drug_res_col
 
                 drugCat = geneToClass[gene_name]
                 if drug_res_col_dict[drugCat] == "neg":
-                    drug_res_col_dict[drugCat] = gene + '(' + allele + ')'
+                    drug_res_col_dict[drugCat] = allele
                 else:
-                    drug_res_col_dict[drugCat] = drug_res_col_dict[drugCat] + ':' + gene + '(' + allele + ')'
+                    drug_res_col_dict[drugCat] = drug_res_col_dict[drugCat] + ':' + allele
 
         if other:
             if drug_res_col_dict["OTHER"] == "neg":
-                drug_res_col_dict["OTHER"] = gene + '(' + allele + ')'
+                drug_res_col_dict["OTHER"] = allele
             else:
-                drug_res_col_dict["OTHER"] = drug_res_col_dict["OTHER"] + ":" + gene + '(' + allele + ')'
+                drug_res_col_dict["OTHER"] = drug_res_col_dict["OTHER"] + ":" + allele
 
 
 def derive_presence_absence_targets_for_arg_res(input_files):
@@ -269,10 +269,9 @@ def derive_presence_absence_targets_for_arg_res(input_files):
                 # Process file lines
                 for line in fd:
                     fields = line.split('\t')
-                    gene = fields[2]
                     allele = fields[3]
                     depth = float(fields[5])
-                    update_presence_absence_target_for_arg_res(gene, allele, depth, drugRes_Col, Res_Targets)
+                    update_presence_absence_target_for_arg_res(allele, depth, drugRes_Col, Res_Targets)
         except IOError:
             print('Cannot open {}.'.format(input_file))
 
@@ -411,7 +410,7 @@ def run(args):
     # Write gbs variant output
     write_output(var_out, args.output + "_res_gbs_variants.txt")
     # Write allele output
-    write_output(allele_out, args.output + "_res_alleles.txt")
+    write_output(allele_out, args.output + "_res_alleles_variants.txt")
 
 
 def get_arguments():

--- a/main.nf
+++ b/main.nf
@@ -62,7 +62,7 @@ tmp_dir.mkdir()
 // Output files
 params.sero_res_incidence_out = "${params.output}_serotype_res_incidence.txt"
 params.variants_out =  "${params.output}_gbs_res_variants.txt"
-params.alleles_out = "${params.output}_drug_cat_alleles.txt"
+params.alleles_variants_out = "${params.output}_drug_cat_alleles_variants.txt"
 
 // Resistance mapping with the GBS resistance database
 workflow GBS_RES {
@@ -149,8 +149,8 @@ workflow {
         combine_results.out.sero_res_incidence
             .collectFile(name: file(params.sero_res_incidence_out), keepHeader: true)
 
-        combine_results.out.res_alleles
-            .collectFile(name: file(params.alleles_out), keepHeader: true)
+        combine_results.out.res_alleles_variants
+            .collectFile(name: file(params.alleles_variants_out), keepHeader: true)
 
         combine_results.out.res_variants
             .collectFile(name: file(params.variants_out), keepHeader: true)

--- a/modules/combine.nf
+++ b/modules/combine.nf
@@ -6,7 +6,7 @@ process combine_results {
 
     output:
     path("${pair_id}_sero_res_incidence.txt"), emit: sero_res_incidence
-    path("${pair_id}_id_alleles.txt"), emit: res_alleles
+    path("${pair_id}_id_alleles_variants.txt"), emit: res_alleles_variants
     path("${pair_id}_id_variants.txt"), emit: res_variants
 
     """

--- a/modules/res_typer.nf
+++ b/modules/res_typer.nf
@@ -5,7 +5,7 @@ process res_typer {
     path(res_dir) // Directory of resistance mapping results
 
     output:
-    tuple val(pair_id), file("${pair_id}_res_incidence.txt"), file("${pair_id}_res_alleles.txt"), file("${pair_id}_res_gbs_variants.txt")
+    tuple val(pair_id), file("${pair_id}_res_incidence.txt"), file("${pair_id}_res_alleles_variants.txt"), file("${pair_id}_res_gbs_variants.txt")
 
     """
     process_res_typer_results.py --srst2_gbs_fullgenes ${res_dir}/${pair_id}/${pair_id}_GBS_RES_*__fullgenes__*__results.txt --srst2_gbs_consensus ${res_dir}/${pair_id}/${pair_id}_consensus_seq.fna --srst2_other_fullgenes ${res_dir}/${pair_id}/${pair_id}_OTHER_RES_*__fullgenes__*__results.txt --min_read_depth ${params.restyper_min_read_depth} --output_prefix ${pair_id}

--- a/tests/combine_results_test.py
+++ b/tests/combine_results_test.py
@@ -55,7 +55,7 @@ class TestCombineResults(unittest.TestCase):
         self.assertEqual(mock_get_sero_res_contents.call_args_list, [call(args.id, args.sero, args.inc)])
         mock_write_output.assert_has_calls([
             call(ANY, args.output + "_sero_res_incidence.txt"),
-            call(ANY, args.output + "_id_alleles.txt"),
+            call(ANY, args.output + "_id_alleles_variants.txt"),
             call(ANY, args.output + "_id_variants.txt")
             ], any_order = False)
         mock_get_content_with_id.assert_has_calls([

--- a/tests/process_res_typer_results_test.py
+++ b/tests/process_res_typer_results_test.py
@@ -299,294 +299,287 @@ class TestProcessResTyperResults(unittest.TestCase):
         # ============== Test ERMB ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"ERMB": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***ERMB***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***ERMB***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***ERMB1***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERMB1***"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
-        update_presence_absence_target_for_arg_res("GENE2", "***ERMB***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***ERMB***):GENE2(***ERMB***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***ERMB2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERMB1***:***ERMB2***"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
 
         # Check low depth
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"ERMB": "neg"}
-        update_presence_absence_target_for_arg_res("GENE2", "***ERMB***", self.MIN_DEPTH-1, drug_res_col_dict, res_target_dict)
+        update_presence_absence_target_for_arg_res("***ERMB***", self.MIN_DEPTH-1, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "neg"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "neg"}, res_target_dict)
 
         # ============== Test TETM ==================
         drug_res_col_dict = {"TET": "neg"}
         res_target_dict = {"TETM": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***TETM***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"TET": "GENE1(***TETM***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***TETM1***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"TET": "***TETM1***"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
-        update_presence_absence_target_for_arg_res("GENE2", "***TETM***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"TET": "GENE1(***TETM***):GENE2(***TETM***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***TETM2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"TET": "***TETM1***:***TETM2***"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
 
         # ============== Test CAT ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {"CAT": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***CAT***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***CAT***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***CAT1***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***CAT1***"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
-        update_presence_absence_target_for_arg_res("GENE2", "***CAT***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***CAT***):GENE2(***CAT***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***CAT2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***CAT1***:***CAT2***"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
 
         # ============== Test LNUB ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"LNUB": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***LNUB***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***LNUB***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***LNUB1***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***LNUB1***"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
-        update_presence_absence_target_for_arg_res("GENE2", "***LNUB***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***LNUB***):GENE2(***LNUB***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***LNUB2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***LNUB1***:***LNUB2***"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
 
         # ============== Test LSAC ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"LSAC": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***LSAC***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***LSAC***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***LSAC1***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***LSAC1***"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
-        update_presence_absence_target_for_arg_res("GENE2", "***LSAC***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***LSAC***):GENE2(***LSAC***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***LSAC2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***LSAC1***:***LSAC2***"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
 
         # ============== Test MEFA ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"MEFA": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***MEFA***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***MEFA***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***MEFA1***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***MEFA1***"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
-        update_presence_absence_target_for_arg_res("GENE2", "***MEFA***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***MEFA***):GENE2(***MEFA***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***MEFA2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***MEFA1***:***MEFA2***"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
 
         # ============== Test FOSA ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {"FOSA": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***fosA***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***fosA***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***fosA***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***fosA***"}, drug_res_col_dict)
         self.assertEqual({"FOSA": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "CAT(***CAT***)"}
+        drug_res_col_dict = {"OTHER": "***CAT***"}
         res_target_dict = {"FOSA": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***fosA***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "CAT(***CAT***):GENE1(***fosA***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***fosA***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***CAT***:***fosA***"}, drug_res_col_dict)
         self.assertEqual({"FOSA": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "FOSA(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***fosA1***"}
         res_target_dict = {"FOSA": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***fosA***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "FOSA(***allele***):GENE1(***fosA***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***fosA2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***fosA1***:***fosA2***"}, drug_res_col_dict)
         self.assertEqual({"FOSA": "pos"}, res_target_dict)
 
         # ============== Test ERMB ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"ERMB": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***erm(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***erm(B)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***erm(B)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***erm(B)***"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "LNUB(***allele***)"}
+        drug_res_col_dict = {"EC": "***LNUB***"}
         res_target_dict = {"ERMB": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***erm(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "LNUB(***allele***):GENE1(***erm(B)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***erm(B)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***LNUB***:***erm(B)***"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "ERMB(***allele***)"}
+        drug_res_col_dict = {"EC": "***erm(B)1***"}
         res_target_dict = {"ERMB": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***erm(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERMB(***allele***):GENE1(***erm(B)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***erm(B)2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***erm(B)1***:***erm(B)2***"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
 
         # ============== Test LNUB ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"LNUB": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***lnu(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***lnu(B)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***lnu(B)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***lnu(B)***"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "ERM(***allele***)"}
+        drug_res_col_dict = {"EC": "***ERMB***"}
         res_target_dict = {"LNUB": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***lnu(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERM(***allele***):GENE1(***lnu(B)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***lnu(B)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERMB***:***lnu(B)***"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "LNUB(***allele***)"}
+        drug_res_col_dict = {"EC": "***lnu(B)1***"}
         res_target_dict = {"LNUB": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***lnu(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "LNUB(***allele***):GENE1(***lnu(B)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***lnu(B)2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***lnu(B)1***:***lnu(B)2***"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
 
         # ============== Test LSAC ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"LSAC": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***lsa(C)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***lsa(C)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***lsa(C)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***lsa(C)***"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "ERM(***allele***)"}
+        drug_res_col_dict = {"EC": "***ERM***"}
         res_target_dict = {"LSAC": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***LSAC***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERM(***allele***):GENE1(***LSAC***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***LSAC***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERM***:***LSAC***"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "ERM(***allele***)"}
+        drug_res_col_dict = {"EC": "***ERM***"}
         res_target_dict = {"LSAC": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***LSAC***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERM(***allele***):GENE1(***LSAC***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***LSAC***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERM***:***LSAC***"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
 
         # ============== Test MEFA ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"MEFA": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***mef(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***mef(A)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***mef(A)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***mef(A)***"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "ERM(***allele***)"}
+        drug_res_col_dict = {"EC": "***ERM***"}
         res_target_dict = {"MEFA": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***mef(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERM(***allele***):GENE1(***mef(A)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***mef(A)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERM***:***mef(A)***"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "ERM(***allele***)"}
+        drug_res_col_dict = {"EC": "***ERM***"}
         res_target_dict = {"MEFA": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***mef(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERM(***allele***):GENE1(***mef(A)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***mef(A)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERM***:***mef(A)***"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
 
         # ============== Test MPHC ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"MPHC": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***mph(C)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "GENE1(***mph(C)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***mph(C)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***mph(C)***"}, drug_res_col_dict)
         self.assertEqual({"MPHC": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "ERMB(***allele***)"}
+        drug_res_col_dict = {"EC": "***ERMB***"}
         res_target_dict = {"MPHC": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***mph(C)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERMB(***allele***):GENE1(***mph(C)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***mph(C)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***ERMB***:***mph(C)***"}, drug_res_col_dict)
         self.assertEqual({"MPHC": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"EC": "MPHC(***allele***)"}
+        drug_res_col_dict = {"EC": "***mph(C)1***"}
         res_target_dict = {"MPHC": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***mph(C)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "MPHC(***allele***):GENE1(***mph(C)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***mph(C)2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"EC": "***mph(C)1***:***mph(C)2***"}, drug_res_col_dict)
         self.assertEqual({"MPHC": "pos"}, res_target_dict)
 
         # ============== Test MSRA ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {"MSRA": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***msr(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***msr(A)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***msr(A)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***msr(A)***"}, drug_res_col_dict)
         self.assertEqual({"MSRA": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "FOSA(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***fos(A)***"}
         res_target_dict = {"MSRA": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***msr(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "FOSA(***allele***):GENE1(***msr(A)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***msr(A)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***fos(A)***:***msr(A)***"}, drug_res_col_dict)
         self.assertEqual({"MSRA": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "MSRA(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***msr(A)1***"}
         res_target_dict = {"MSRA": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***msr(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "MSRA(***allele***):GENE1(***msr(A)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***msr(A)2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***msr(A)1***:***msr(A)2***"}, drug_res_col_dict)
         self.assertEqual({"MSRA": "pos"}, res_target_dict)
 
         # ============== Test MSRD ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {"MSRD": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***msr(D)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***msr(D)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***msr(D)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***msr(D)***"}, drug_res_col_dict)
         self.assertEqual({"MSRD": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "FOSA(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***FOSA***"}
         res_target_dict = {"MSRD": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***msr(D)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "FOSA(***allele***):GENE1(***msr(D)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***msr(D)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***FOSA***:***msr(D)***"}, drug_res_col_dict)
         self.assertEqual({"MSRD": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "MSRD(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***msr(D)1***"}
         res_target_dict = {"MSRD": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***msr(D)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "MSRD(***allele***):GENE1(***msr(D)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***msr(D)2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***msr(D)1***:***msr(D)2***"}, drug_res_col_dict)
         self.assertEqual({"MSRD": "pos"}, res_target_dict)
 
         # ============== Test SUL2 ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {"SUL2": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***sul2***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***sul2***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***sul2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***sul2***"}, drug_res_col_dict)
         self.assertEqual({"SUL2": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "FOSA(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***FOSA***"}
         res_target_dict = {"SUL2": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***sul2***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "FOSA(***allele***):GENE1(***sul2***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***sul2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***FOSA***:***sul2***"}, drug_res_col_dict)
         self.assertEqual({"SUL2": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "SUL2(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***sul2_1***"}
         res_target_dict = {"SUL2": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***sul2***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "SUL2(***allele***):GENE1(***sul2***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***sul2_2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***sul2_1***:***sul2_2***"}, drug_res_col_dict)
         self.assertEqual({"SUL2": "pos"}, res_target_dict)
 
         # ============== Test TETM ==================
         drug_res_col_dict = {"TET": "neg"}
         res_target_dict = {"TETM": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***tet(M)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"TET": "GENE1(***tet(M)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***tet(M)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"TET": "***tet(M)***"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"TET": "ERM(***allele***)"}
+        drug_res_col_dict = {"TET": "***ERM***"}
         res_target_dict = {"TETM": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***tet(M)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"TET": "ERM(***allele***):GENE1(***tet(M)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***tet(M)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"TET": "***ERM***:***tet(M)***"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"TET": "ERM(***allele***)"}
+        drug_res_col_dict = {"TET": "***ERM***"}
         res_target_dict = {"TETM": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***tet(M)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"TET": "ERM(***allele***):GENE1(***tet(M)***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***tet(M)***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"TET": "***ERM***:***tet(M)***"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
 
         # ============== Test CAT ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {"CAT": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***CAT***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***CAT***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***CAT***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***CAT***"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "ERM(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***ERM***"}
         res_target_dict = {"CAT": "neg"}
-        update_presence_absence_target_for_arg_res("GENE1", "***CAT***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "ERM(***allele***):GENE1(***CAT***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***CAT***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***ERM***:***CAT***"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
 
-        drug_res_col_dict = {"OTHER": "CAT(***allele***)"}
+        drug_res_col_dict = {"OTHER": "***CAT1***"}
         res_target_dict = {"CAT": "pos"}
-        update_presence_absence_target_for_arg_res("GENE1", "***CAT***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "CAT(***allele***):GENE1(***CAT***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***CAT2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***CAT1***:***CAT2***"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
 
         # ============== Test OTHER ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {}
-        update_presence_absence_target_for_arg_res("GENE1", "***FOO***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***FOO***)"}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***FOO1***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***FOO1***"}, drug_res_col_dict)
         self.assertEqual({}, res_target_dict)
-        update_presence_absence_target_for_arg_res("GENE2", "***FOO***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "GENE1(***FOO***):GENE2(***FOO***)"}, drug_res_col_dict)
-        self.assertEqual({}, res_target_dict)
-
-        # ============== Test depth ==================
-        drug_res_col_dict = {}
-        res_target_dict = {}
-        update_presence_absence_target_for_arg_res("GENE1", "***CAT***", self.MIN_DEPTH - 1, drug_res_col_dict, res_target_dict)
-        self.assertEqual({}, drug_res_col_dict)
+        update_presence_absence_target_for_arg_res("***FOO2***", depth, drug_res_col_dict, res_target_dict)
+        self.assertEqual({"OTHER": "***FOO1***:***FOO2***"}, drug_res_col_dict)
         self.assertEqual({}, res_target_dict)
 
     @patch('bin.process_res_typer_results.update_presence_absence_target')
@@ -599,9 +592,9 @@ class TestProcessResTyperResults(unittest.TestCase):
     @patch('bin.process_res_typer_results.update_presence_absence_target_for_arg_res')
     def derive_presence_absence_targets_for_arg_res(self, mock):
         calls = [
-            call("tet(M)", "tet(M)_12", 132.04, ANY, ANY),
-            call("tet(M)", "tet(M)_4", 185.331, ANY, ANY),
-            call("tet(M)", "tet(M)_10", 120.412, ANY, ANY),
+            call("tet(M)_12", 132.04, ANY, ANY),
+            call("tet(M)_4", 185.331, ANY, ANY),
+            call("tet(M)_10", 120.412, ANY, ANY),
         ]
         derive_presence_absence_targets_for_arg_res(self.TEST_RESFINDER_FULLGENES_RESULTS_FILE)
         mock.assert_has_calls(calls, any_order=False)
@@ -802,7 +795,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         mock_write_output.assert_has_calls([
             call(ANY, args.output + '_res_incidence.txt'),
             call(ANY, args.output + "_res_gbs_variants.txt"),
-            call(ANY, args.output + "_res_alleles.txt")
+            call(ANY, args.output + "_res_alleles_variants.txt")
         ], any_order = False)
 
     def test_arguments(self):

--- a/tests/process_res_typer_results_test.py
+++ b/tests/process_res_typer_results_test.py
@@ -273,119 +273,95 @@ class TestProcessResTyperResults(unittest.TestCase):
     def test_update_presence_absence_target(self):
         depth = self.MIN_DEPTH+1
 
+
+        # ============== Test misc ==================
+        misc_list = ["PARC", "GYRA", "23S1", "23S3", "RPOBGBS-1"]
+        for allele in misc_list:
+            gbs_res_target_dict = {allele: "neg"}
+            update_presence_absence_target("GENE1", "***"+allele+"***", depth, gbs_res_target_dict)
+            self.assertEqual({allele: "pos"}, gbs_res_target_dict)
+
+        # ============== Test RPOBgbs-N ==================
+        gbs_res_target_dict = {"RPOBGBS-2": "neg"}
+        update_presence_absence_target("GENE1", "***RPOBGBS-2***", depth, gbs_res_target_dict)
+        self.assertEqual({"RPOBGBS-2": "pos"}, gbs_res_target_dict)
+
+        # ============== Test depth ==================
+        gbs_res_target_dict = {}
+        update_presence_absence_target("GENE1", "***RPOBGBS-1***", self.MIN_DEPTH-1, gbs_res_target_dict)
+        self.assertEqual({}, gbs_res_target_dict)
+
+        # TODO there is a suspected bug in this perl code - see Python module
+
+    def test_update_presence_absence_target_for_arg_res(self):
+        depth = self.MIN_DEPTH+1
+
         # ============== Test ERMB ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"ERMB": "neg"}
-        gbs_res_target_dict = {"GYRA": "neg"}
-        update_presence_absence_target("GENE1", "***ERMB***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE1", "***ERMB***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***ERMB***)"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
-        update_presence_absence_target("GENE2", "***ERMB***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE2", "***ERMB***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***ERMB***):GENE2(***ERMB***)"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
 
         # Check low depth
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"ERMB": "neg"}
-        update_presence_absence_target("GENE2", "***ERMB***", self.MIN_DEPTH-1, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE2", "***ERMB***", self.MIN_DEPTH-1, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "neg"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "neg"}, res_target_dict)
 
         # ============== Test TETM ==================
         drug_res_col_dict = {"TET": "neg"}
         res_target_dict = {"TETM": "neg"}
-        update_presence_absence_target("GENE1", "***TETM***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE1", "***TETM***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"TET": "GENE1(***TETM***)"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
-        update_presence_absence_target("GENE2", "***TETM***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE2", "***TETM***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"TET": "GENE1(***TETM***):GENE2(***TETM***)"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
 
         # ============== Test CAT ==================
         drug_res_col_dict = {"OTHER": "neg"}
         res_target_dict = {"CAT": "neg"}
-        update_presence_absence_target("GENE1", "***CAT***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE1", "***CAT***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"OTHER": "GENE1(***CAT***)"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
-        update_presence_absence_target("GENE2", "***CAT***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE2", "***CAT***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"OTHER": "GENE1(***CAT***):GENE2(***CAT***)"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
 
         # ============== Test LNUB ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"LNUB": "neg"}
-        update_presence_absence_target("GENE1", "***LNUB***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE1", "***LNUB***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***LNUB***)"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
-        update_presence_absence_target("GENE2", "***LNUB***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE2", "***LNUB***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***LNUB***):GENE2(***LNUB***)"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
 
         # ============== Test LSAC ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"LSAC": "neg"}
-        update_presence_absence_target("GENE1", "***LSAC***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE1", "***LSAC***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***LSAC***)"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
-        update_presence_absence_target("GENE2", "***LSAC***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE2", "***LSAC***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***LSAC***):GENE2(***LSAC***)"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
 
         # ============== Test MEFA ==================
         drug_res_col_dict = {"EC": "neg"}
         res_target_dict = {"MEFA": "neg"}
-        update_presence_absence_target("GENE1", "***MEFA***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE1", "***MEFA***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***MEFA***)"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
-        update_presence_absence_target("GENE2", "***MEFA***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
+        update_presence_absence_target_for_arg_res("GENE2", "***MEFA***", depth, drug_res_col_dict, res_target_dict)
         self.assertEqual({"EC": "GENE1(***MEFA***):GENE2(***MEFA***)"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
-
-        # ============== Test misc ==================
-        misc_list = ["PARC", "GYRA", "23S1", "23S3", "RPOBGBS-1"]
-        drug_res_col_dict = {'TET': 'neg',
-                            'EC': 'neg',
-                            'FQ': 'neg',
-                            'OTHER': 'neg',}
-        for allele in misc_list:
-            res_target_dict = {allele: "neg"}
-            update_presence_absence_target("GENE1", "***"+allele+"***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
-        self.assertEqual({'TET': 'neg',
-                            'EC': 'GENE1(***23S1***):GENE1(***23S3***)',
-                            'FQ': 'GENE1(***PARC***):GENE1(***GYRA***)',
-                            'OTHER': 'GENE1(***RPOBGBS-1***)'}, drug_res_col_dict)
-        self.assertEqual({allele: "pos"}, res_target_dict)
-
-        # ============== Test RPOBgbs-N ==================
-        drug_res_col_dict = {'TET': 'neg',
-                            'EC': 'neg',
-                            'FQ': 'neg',
-                            'OTHER': 'neg',}
-        res_target_dict = {"RPOBGBS-2": "neg"}
-        update_presence_absence_target("GENE1", "***RPOBGBS-2***", depth, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
-        self.assertEqual({'TET': 'neg',
-                            'EC': 'neg',
-                            'FQ': 'neg',
-                            'OTHER': 'GENE1(***RPOBGBS-2***)'}, drug_res_col_dict)
-        self.assertEqual({"RPOBGBS-2": "pos"}, res_target_dict)
-
-        # ============== Test depth ==================
-        drug_res_col_dict = {'TET': 'neg',
-                            'EC': 'neg',
-                            'FQ': 'neg',
-                            'OTHER': 'neg',}
-        res_target_dict = {}
-        update_presence_absence_target("GENE1", "***RPOBGBS-1***", self.MIN_DEPTH-1, drug_res_col_dict, res_target_dict, gbs_res_target_dict)
-        self.assertEqual({'TET': 'neg',
-                            'EC': 'neg',
-                            'FQ': 'neg',
-                            'OTHER': 'neg'}, drug_res_col_dict)
-        self.assertEqual({}, res_target_dict)
-
-        # TODO there is a suspected bug in this perl code - see Python module
-
-    def test_update_presence_absence_target_for_arg_res(self):
-        depth = self.MIN_DEPTH+1
 
         # ============== Test FOSA ==================
         drug_res_col_dict = {"OTHER": "neg"}
@@ -403,7 +379,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"OTHER": "FOSA(***allele***)"}
         res_target_dict = {"FOSA": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***fosA***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "FOSA(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"OTHER": "FOSA(***allele***):GENE1(***fosA***)"}, drug_res_col_dict)
         self.assertEqual({"FOSA": "pos"}, res_target_dict)
 
         # ============== Test ERMB ==================
@@ -422,7 +398,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"EC": "ERMB(***allele***)"}
         res_target_dict = {"ERMB": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***erm(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERMB(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"EC": "ERMB(***allele***):GENE1(***erm(B)***)"}, drug_res_col_dict)
         self.assertEqual({"ERMB": "pos"}, res_target_dict)
 
         # ============== Test LNUB ==================
@@ -441,7 +417,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"EC": "LNUB(***allele***)"}
         res_target_dict = {"LNUB": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***lnu(B)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "LNUB(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"EC": "LNUB(***allele***):GENE1(***lnu(B)***)"}, drug_res_col_dict)
         self.assertEqual({"LNUB": "pos"}, res_target_dict)
 
         # ============== Test LSAC ==================
@@ -460,7 +436,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"EC": "ERM(***allele***)"}
         res_target_dict = {"LSAC": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***LSAC***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERM(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"EC": "ERM(***allele***):GENE1(***LSAC***)"}, drug_res_col_dict)
         self.assertEqual({"LSAC": "pos"}, res_target_dict)
 
         # ============== Test MEFA ==================
@@ -479,7 +455,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"EC": "ERM(***allele***)"}
         res_target_dict = {"MEFA": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***mef(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "ERM(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"EC": "ERM(***allele***):GENE1(***mef(A)***)"}, drug_res_col_dict)
         self.assertEqual({"MEFA": "pos"}, res_target_dict)
 
         # ============== Test MPHC ==================
@@ -498,7 +474,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"EC": "MPHC(***allele***)"}
         res_target_dict = {"MPHC": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***mph(C)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"EC": "MPHC(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"EC": "MPHC(***allele***):GENE1(***mph(C)***)"}, drug_res_col_dict)
         self.assertEqual({"MPHC": "pos"}, res_target_dict)
 
         # ============== Test MSRA ==================
@@ -517,7 +493,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"OTHER": "MSRA(***allele***)"}
         res_target_dict = {"MSRA": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***msr(A)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "MSRA(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"OTHER": "MSRA(***allele***):GENE1(***msr(A)***)"}, drug_res_col_dict)
         self.assertEqual({"MSRA": "pos"}, res_target_dict)
 
         # ============== Test MSRD ==================
@@ -536,7 +512,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"OTHER": "MSRD(***allele***)"}
         res_target_dict = {"MSRD": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***msr(D)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "MSRD(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"OTHER": "MSRD(***allele***):GENE1(***msr(D)***)"}, drug_res_col_dict)
         self.assertEqual({"MSRD": "pos"}, res_target_dict)
 
         # ============== Test SUL2 ==================
@@ -555,7 +531,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"OTHER": "SUL2(***allele***)"}
         res_target_dict = {"SUL2": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***sul2***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "SUL2(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"OTHER": "SUL2(***allele***):GENE1(***sul2***)"}, drug_res_col_dict)
         self.assertEqual({"SUL2": "pos"}, res_target_dict)
 
         # ============== Test TETM ==================
@@ -574,7 +550,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"TET": "ERM(***allele***)"}
         res_target_dict = {"TETM": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***tet(M)***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"TET": "ERM(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"TET": "ERM(***allele***):GENE1(***tet(M)***)"}, drug_res_col_dict)
         self.assertEqual({"TETM": "pos"}, res_target_dict)
 
         # ============== Test CAT ==================
@@ -593,7 +569,7 @@ class TestProcessResTyperResults(unittest.TestCase):
         drug_res_col_dict = {"OTHER": "CAT(***allele***)"}
         res_target_dict = {"CAT": "pos"}
         update_presence_absence_target_for_arg_res("GENE1", "***CAT***", depth, drug_res_col_dict, res_target_dict)
-        self.assertEqual({"OTHER": "CAT(***allele***)"}, drug_res_col_dict)
+        self.assertEqual({"OTHER": "CAT(***allele***):GENE1(***CAT***)"}, drug_res_col_dict)
         self.assertEqual({"CAT": "pos"}, res_target_dict)
 
         # ============== Test OTHER ==================
@@ -616,16 +592,16 @@ class TestProcessResTyperResults(unittest.TestCase):
     @patch('bin.process_res_typer_results.update_presence_absence_target')
     def test_derive_presence_absence_targets(self, mock):
 
-        calls = [call("23S1", "23S1-1", 1135.571, ANY, ANY, ANY), call("23S3", "23S3-3", 1265.721, ANY, ANY, ANY)]
+        calls = [call("23S1", "23S1-1", 1135.571, ANY), call("23S3", "23S3-3", 1265.721, ANY)]
         derive_presence_absence_targets(self.TEST_GBS_FULLGENES_RESULTS_FILE)
         mock.assert_has_calls(calls, any_order=False)
 
     @patch('bin.process_res_typer_results.update_presence_absence_target_for_arg_res')
     def derive_presence_absence_targets_for_arg_res(self, mock):
         calls = [
-            call("tet(M)", "tet(M)_12", 132.04, ANY, ANY, ANY),
-            call("tet(M)", "tet(M)_4", 185.331, ANY, ANY, ANY),
-            call("tet(M)", "tet(M)_10", 120.412, ANY, ANY, ANY),
+            call("tet(M)", "tet(M)_12", 132.04, ANY, ANY),
+            call("tet(M)", "tet(M)_4", 185.331, ANY, ANY),
+            call("tet(M)", "tet(M)_10", 120.412, ANY, ANY),
         ]
         derive_presence_absence_targets_for_arg_res(self.TEST_RESFINDER_FULLGENES_RESULTS_FILE)
         mock.assert_has_calls(calls, any_order=False)


### PR DESCRIPTION
Dorota asked whether we could change the drug category output to just include the GBS-specific variants and the other resistance alleles. (Before it was GBS-specific alleles and other resistance genes and alleles)