### PR TITLE
fix copying reference db to tmp folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,21 @@ nextflow run main.nf --reads 'data/*_{1,2}.fastq.gz' --output 'output_file_prefi
 This will produce combined tables of output_file_prefix_serotype_res_incidence.txt, output_file_prefix_gbs_res_variants.txt and output_file_prefix_drug_cat_alleles.txt in the 'results' directory that can be identified by sample ID (i.e. the name of the file before _1.fastq.gz or _2.fastq.gz).
 
 #### Additional useful options
-    --dbversion                 Database version. (Default: 0.0.2)
+##### Inputs
+    --db_version                Database version. (Default: 0.0.2)
+    --other_res_dbs             Paths to other resistance reference database(s). Must be FASTA format. Specify 'none' to omit using other resistance databases. (Default: 'db/0.0.2/ARGannot-DB/ARG-ANNOT.fasta db/0.0.2/ResFinder-DB/ResFinder.fasta')
+
+##### Outputs
+    --results_dir               Results directory for output files. (Default: './results')
+    --tmp_dir                   Temporary directory for intermediate files. (Default: './tmp')
+
+##### Parameters
     --gbs_res_min_coverage      Minimum coverage for mapping to the GBS resistance database. (Default: 99.9)
     --gbs_res_max_divergence    Maximum divergence for mapping to the GBS resistance database. (Default: 5)
-    --other_res_dbs             Paths to other resistance reference database(s). Must be FASTA format. Specify 'none' to omit using other resistance databases. (Default: 'db/0.0.2/ARGannot-DB/ARG-ANNOT.fasta db/0.0.2/ResFinder-DB/ResFinder.fasta')
     --other_res_min_coverage    Minimum coverage for mapping to other resistance reference database(s). Number of values must equal the number of resistance reference database files and must correspond to the order specified in --other_res_dbs. (Default: '70 70')
     --other_res_max_divergence  Maximum divergence for mapping to other resistance reference database(s). Number of values must equal the number of resistance reference database files and must correspond to the order specified in --other_res_dbs. (Default: '30 30')
     --restyper_min_read_depth   Minimum read depth where mappings to antibiotic resistance genes with fewer reads are excluded. (Default: 30)
     --serotyper_min_read_depth  Minimum read depth where mappings to serotyping genes with fewer reads are excluded. (Default: 30)
-
-    -resume                   Resume if pipeline does not complete.
 
 ### Running on farm5
 1. Load modules

--- a/main.nf
+++ b/main.nf
@@ -56,11 +56,11 @@ if (params.other_res_dbs.toString() != 'none'){
 }
 
 // Create tmp directory if it doesn't already exist
-tmp_dir = file('./tmp')
+tmp_dir = file(params.tmp_dir)
 tmp_dir.mkdir()
 
 // Results directory
-results_dir = file('./results')
+results_dir = file(params.results_dir)
 
 // Output files
 params.sero_res_incidence_out = "${params.output}_serotype_res_incidence.txt"

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -3,16 +3,34 @@ def printHelp() {
   log.info"""
   Usage:
     nextflow run main.nf --reads [paired reads] --output [output prefix]
+
   Description:
     Serotyping and resistance typing of Group B Strep.
+
   Additional options:
-    --dbversion                 Database version. (Default: 0.0.2)
-    --gbs_res_min_coverage      Minimum coverage for mapping to the GBS resistance database. (Default: 99.9)
-    --gbs_res_max_divergence    Maximum divergence for mapping to the GBS resistance database. (Default: 5)
-    --other_res_dbs             Paths to other resistance reference database(s). Must be FASTA format. Specify 'none' to omit using other resistance databases. (Default: 'db/0.0.2/ARGannot-DB/ARG-ANNOT.fasta db/0.0.2/ResFinder-DB/ResFinder.fasta')
-    --other_res_min_coverage    Minimum coverage for mapping to other resistance reference database(s). Number of values must equal the number of resistance reference database files and must correspond to the order specified in --other_res_dbs. (Default: '70 70')
-    --other_res_max_divergence  Maximum divergence for mapping to other resistance reference database(s). Number of values must equal the number of resistance reference database files and must correspond to the order specified in --other_res_dbs. (Default: '30 30')
-    --restyper_min_read_depth   Minimum read depth where mappings to antibiotic resistance genes with fewer reads are excluded. (Default: 30)
-    --serotyper_min_read_depth  Minimum read depth where mappings to serotyping genes with fewer reads are excluded. (Default: 30)
+
+    Inputs:
+      --db_version                  Database version. (Default: 0.0.2)
+      --other_res_dbs               Paths to other resistance reference database(s). Must be FASTA format.
+                                    Specify 'none' to omit using other resistance databases.
+                                    (Default: 'db/0.0.2/ARGannot-DB/ARG-ANNOT.fasta db/0.0.2/ResFinder-DB/ResFinder.fasta')
+
+    Outputs:
+      --results_dir                 Results directory for output files. (Default: './results')
+      --tmp_dir                     Temporary directory for intermediate files. (Default: './tmp')
+
+    Parameters:
+      --gbs_res_min_coverage        Minimum coverage for mapping to the GBS resistance database. (Default: 99.9)
+      --gbs_res_max_divergence      Maximum divergence for mapping to the GBS resistance database. (Default: 5)
+      --other_res_min_coverage      Minimum coverage for mapping to other resistance reference database(s).
+                                    Number of values must equal the number of resistance reference database files
+                                    and must correspond to the order specified in --other_res_dbs. (Default: '70 70')
+      --other_res_max_divergence    Maximum divergence for mapping to other resistance reference database(s).
+                                    Number of values must equal the number of resistance reference database files
+                                    and must correspond to the order specified in --other_res_dbs. (Default: '30 30')
+      --restyper_min_read_depth     Minimum read depth where mappings to antibiotic resistance genes with fewer
+                                    reads are excluded. (Default: 30)
+      --serotyper_min_read_depth    Minimum read depth where mappings to serotyping genes with fewer reads are excluded.
+                                    (Default: 30)
   """.stripIndent()
 }

--- a/modules/res_alignments.nf
+++ b/modules/res_alignments.nf
@@ -4,11 +4,12 @@ process srst2_for_res_typing {
     tuple val(pair_id), file(reads) // ID and paired read files
     val(dbs) // String of resistance database file(s)
     path(db_dir) // Path to database file(s)
+    path(tmp_dir) // Path to temporary directory
     val(db_name) // Type of resistance database i.e. GBS or OTHER
     val(min_coverage) // String of minimum coverage parameter(s) for SRST2
     val(max_divergence) // String of maximum coverage parameter(s) for SRST2
 
-    publishDir "./tmp/${pair_id}", mode: 'copy', overwrite: true
+    publishDir "./${tmp_dir}/${pair_id}", mode: 'move', overwrite: true, pattern: "${pair_id}_${db_name}_*__fullgenes__*__results.txt"
 
     output:
     tuple val(pair_id), file("${pair_id}*.bam"), emit: bam_files
@@ -27,8 +28,11 @@ process srst2_for_res_typing {
 
     for ((i=0;i<\${#db_array[@]};i++));
     do
+        mkdir -p ${tmp_dir}/${pair_id}
+        cp ${db_dir}/\${db_array[i]} ${tmp_dir}/${pair_id}/
         db_file=\$(basename \${db_array[i]})
-        srst2 --samtools_args '\\-A' --input_pe ${reads[0]} ${reads[1]} --output ${pair_id}_${db_name}_\${db_file} --log --save_scores --min_coverage \${min_cov_array[i]} --max_divergence \${max_div_array[i]} --gene_db ${db_dir}/\${db_file}
+        srst2 --samtools_args '\\-A' --input_pe ${reads[0]} ${reads[1]} --output ${pair_id}_${db_name}_\${db_file} --log --save_scores --min_coverage \${min_cov_array[i]} --max_divergence \${max_div_array[i]} --gene_db ${tmp_dir}/${pair_id}/\${db_file}
+        rm ${tmp_dir}/${pair_id}/\${db_file}*
     done
     """
 }
@@ -75,8 +79,9 @@ process freebayes {
     file(target_bam) // BAM file from a mapped target sequence of interest
     file(target_bai) // Corresponding BAM index file
     file(target_ref) // FASTA file of target sequence
+    path(tmp_dir)
 
-    publishDir "./tmp/${pair_id}", mode: 'copy', overwrite: true
+    publishDir "./${tmp_dir}/${pair_id}", mode: 'move', overwrite: true
 
     output:
     val(pair_id), emit: id

--- a/modules/res_typer.nf
+++ b/modules/res_typer.nf
@@ -9,5 +9,6 @@ process res_typer {
 
     """
     process_res_typer_results.py --srst2_gbs_fullgenes ${res_dir}/${pair_id}/${pair_id}_GBS_RES_*__fullgenes__*__results.txt --srst2_gbs_consensus ${res_dir}/${pair_id}/${pair_id}_consensus_seq.fna --srst2_other_fullgenes ${res_dir}/${pair_id}/${pair_id}_OTHER_RES_*__fullgenes__*__results.txt --min_read_depth ${params.restyper_min_read_depth} --output_prefix ${pair_id}
+    rm ${res_dir}/${pair_id}/${pair_id}*
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,15 +10,17 @@ manifest {
 params {
     reads = ""
     output = ""
-    dbversion = "0.0.2"
-    dbdir = "./db/$dbversion"
-    serotyping_db = "$dbdir/GBS_seroT_Gene-DB/GBS_seroT_Gene-DB_Final.fasta"
+    db_version = "0.0.2"
+    db_dir = "./db/$db_version"
+    tmp_dir = "./tmp"
+    results_dir = "./results"
+    serotyping_db = "$db_dir/GBS_seroT_Gene-DB/GBS_seroT_Gene-DB_Final.fasta"
     serotyper_min_read_depth = 30
-    gbs_res_typer_db = "$dbdir/GBS_resTyper_Gene-DB/GBS_Res_Gene-DB_Final.fasta"
-    gbs_res_targets_db = "$dbdir/GBS_resTyper_Gene-DB/seqs_of_interest.txt"
+    gbs_res_typer_db = "$db_dir/GBS_resTyper_Gene-DB/GBS_Res_Gene-DB_Final.fasta"
+    gbs_res_targets_db = "$db_dir/GBS_resTyper_Gene-DB/seqs_of_interest.txt"
     gbs_res_min_coverage = 99.9
     gbs_res_max_divergence = 5
-    other_res_dbs = "$dbdir/ARGannot-DB/ARG-ANNOT.fasta $dbdir/ResFinder-DB/ResFinder.fasta"
+    other_res_dbs = "$db_dir/ARGannot-DB/ARG-ANNOT.fasta $db_dir/ResFinder-DB/ResFinder.fasta"
     other_res_min_coverage = "70 70"
     other_res_max_divergence = "30 30"
     restyper_min_read_depth = 30


### PR DESCRIPTION
The reference db is now being copied to ./tmp/<pair id> instead of ./tmp/, which I hope should fix the potential copyTo issue. I've also removed the hard coded 'tmp' in the publishDir function and also added 'rm ./tmp/<pair_id>/<pair_id>* that may be a safer option than deleting an entire directory.