### PR TITLE
Added an LSF configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ cd GBS-Typer-sanger-nf
 
 2. Load modules
 ```
-module load ISG/singularity/3.6.4
-module load nextflow/20.10.0-5430
+module load ISG/singularity
+module load nextflow
 ```
 
 3. For a single sample, run using bsub and add '-profile sanger' as an option, e.g.
@@ -54,11 +54,11 @@ module load nextflow/20.10.0-5430
 bsub -G <your_team> -J <job_name> -o %J.out -e %J.err -R "select[mem>1000] rusage[mem=1000]" -M1000 "nextflow run main.nf --reads 'data/sampleID_{1,2}.fastq.gz' --output 'sampleID' -profile sanger"
 ```
 
-4. For multiple samples, also run using bsub and add '-profile sanger', e.g.
+4. For multiple samples, also run using bsub and add '-profile sanger,lsf', e.g.
 ```
-bsub -G <your_team> -J <job_name> -o %J.out -e %J.err -R "select[mem>1000] rusage[mem=1000]" -M1000 "nextflow run main.nf --reads 'data/*_{1,2}.fastq.gz' --output 'output_file_prefix' -profile sanger"
+bsub -G <your_team> -J <job_name> -o %J.out -e %J.err -R "select[mem>1000] rusage[mem=1000]" -M1000 "nextflow run main.nf --reads 'data/*_{1,2}.fastq.gz' --output 'output_file_prefix' -profile sanger,lsf"
 ```
-This will automatically generate a separate bsub job for each sample in parallel.
+This will instruct Nextflow to run tasks as separate LSF jobs in parallel and can be significantly faster. The default is to run up to 20 jobs at a time. The default settings can be tuned to your requirements by editing the **lsf** profile within the nextflow.config file.
 
 
 ## Output

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ bsub -G <your_team> -J <job_name> -o %J.out -e %J.err -R "select[mem>1000] rusag
 ```
 This will instruct Nextflow to run tasks as separate LSF jobs in parallel and can be significantly faster. The default is to run up to 20 jobs at a time. The default settings can be tuned to your requirements by editing the **lsf** profile within the nextflow.config file.
 
+Add a **-N 'my-email-address'** to the end of the command line if you wish to be sent a report by email upon completion of the pipeline.
+
 
 ## Output
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,3 +1,4 @@
+// Dependencies docker image
 process.container = 'sangerpathogens/gbs-typer-sanger-nf:0.0.4'
 
 manifest {
@@ -35,6 +36,23 @@ profiles {
         }
     }
 
+    // Basic configuration for an LSF environment
+    lsf {
+        process.cpus = 1
+        process.memory = "2GB"
+        process.queue = "normal"
+        process.errorStrategy = { sleep(task.attempt * 200); return 'retry' }
+        process.maxRetries = 3
+        executor {
+            name = "lsf"
+            // Maximum number of jobs to spawn at once - adjust as necessary
+            queueSize = 20
+            jobName = { "gbstyper - $task.name - $task.hash" }
+            pollInterval = "5 sec"
+        }
+    }
+
+    // Singularity configuration used by the Sanger Institute
     sanger {
         docker {
              enabled = false


### PR DESCRIPTION
Running multiple parallel bsubs on the pipeline directory is not recommended. Therefore I've added an LSF profile to enable nextflow to manage the scheduling itself. This significantly improves performance for a large number of samples.  The max number of jobs allowed to run at any one time is set to 20 by default, but this can be changed as required in the nextflow.config. A retry policy has also been added. See README for details.