### PR TITLE
Pipeline checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ This will produce combined tables of output_file_prefix_serotype_res_incidence.t
 
 ### Parameters
     --gbs_res_min_coverage      Minimum coverage for mapping to the GBS resistance database. (Default: 99.9)
-    --gbs_res_max_divergence    Maximum divergence for mapping to the GBS resistance database. (Default: 5)
+    --gbs_res_max_divergence    Maximum divergence for mapping to the GBS resistance database. (Default: 5, i.e. report only hits with <5% divergence)
     --other_res_min_coverage    Minimum coverage for mapping to other resistance reference database(s). Number of values must equal the number of resistance reference database files and must correspond to the order specified in --other_res_dbs. (Default: 70)
-    --other_res_max_divergence  Maximum divergence for mapping to other resistance reference database(s). Number of values must equal the number of resistance reference database files and must correspond to the order specified in --other_res_dbs. (Default: 30)
+    --other_res_max_divergence  Maximum divergence for mapping to other resistance reference database(s). Number of values must equal the number of resistance reference database files and must correspond to the order specified in --other_res_dbs. (Default: 30, i.e. report only hits with <30% divergence)
     --restyper_min_read_depth   Minimum read depth where mappings to antibiotic resistance genes with fewer reads are excluded. (Default: 30)
     --serotyper_min_read_depth  Minimum read depth where mappings to serotyping genes with fewer reads are excluded. (Default: 30)
 

--- a/bin/process_res_typer_results.py
+++ b/bin/process_res_typer_results.py
@@ -423,8 +423,8 @@ def get_arguments():
     parser.add_argument('--srst2_other_fullgenes', dest='srst2_other_fg_output', required=False,
                         help='Input SRST2 fullgenes outputs for other references databases.',
                         nargs = '*')
-    parser.add_argument('--min_read_depth', dest='min_depth', required=True, type=int, default=30,
-                        help = 'Minimum read depth where mappings with fewer reads are excluded.')
+    parser.add_argument('--min_read_depth', dest='min_depth', required=True, type=float, default=30,
+                        help = 'Minimum read depth where mappings with fewer reads are excluded. Default: 30.')
     parser.add_argument('--output_prefix', dest='output', required=True,
                         help='Output prefix of filename.')
 

--- a/bin/process_serotyper_results.py
+++ b/bin/process_serotyper_results.py
@@ -39,8 +39,8 @@ def get_arguments():
                         help='Input fullgenes results tab file.')
     parser.add_argument('--output', '-o', dest='output', required=True,
                         help='Output filename.')
-    parser.add_argument('--min_read_depth', '-d', dest='depth', default = 10, type=int,
-                        help='Include SNPs greater than depth threshold. Default: 10.')
+    parser.add_argument('--min_read_depth', '-d', dest='depth', default = 30, type=float,
+                        help='Minimum read depth where mappings with fewer reads are excluded. Default: 30.')
 
     return parser
 

--- a/main.nf
+++ b/main.nf
@@ -55,6 +55,43 @@ if (params.other_res_dbs.toString() != 'none'){
     }
 }
 
+// Check parameters are within range
+if (params.gbs_res_min_coverage < 0 | params.gbs_res_min_coverage > 100){
+    println("--gbs_res_min_coverage value not in range. Please specify a value between 0 and 100.")
+    System.exit(1)
+}
+
+if (params.gbs_res_max_divergence < 0 | params.gbs_res_max_divergence > 100){
+    println("--gbs_res_max_divergence value not in range. Please specify a value between 0 and 100.")
+    System.exit(1)
+}
+
+other_res_min_coverage_list = params.other_res_min_coverage.toString().tokenize(' ')
+for (other_res_min_coverage in other_res_min_coverage_list){
+    if (other_res_min_coverage.toDouble() < 0 | other_res_min_coverage.toDouble() > 100){
+        println("--other_res_min_coverage value(s) not in range. Please specify a value between 0 and 100.")
+        System.exit(1)
+    }
+}
+
+other_res_max_divergence_list = params.other_res_max_divergence.toString().tokenize(' ')
+for (other_res_max_divergence in other_res_max_divergence_list){
+    if (other_res_max_divergence.toDouble() < 0 | other_res_max_divergence.toDouble() > 100){
+        println("--other_res_max_divergence value(s) not in range. Please specify a value between 0 and 100.")
+        System.exit(1)
+    }
+}
+
+if (params.restyper_min_read_depth < 0){
+    println("--restyper_min_read_depth value not in range. Please specify a value of 0 or above.")
+    System.exit(1)
+}
+
+if (params.serotyper_min_read_depth < 0){
+    println("--serotyper_min_read_depth value not in range. Please specify a value of 0 or above.")
+    System.exit(1)
+}
+
 // Create tmp directory if it doesn't already exist
 tmp_dir = file(params.tmp_dir)
 tmp_dir.mkdir()

--- a/main.nf
+++ b/main.nf
@@ -122,7 +122,7 @@ workflow {
     main:
 
         // Serotyping Process
-        serotyping(read_pairs_ch, file(params.serotyping_db))
+        serotyping(read_pairs_ch, file(params.serotyping_db), params.serotyper_min_read_depth)
 
         // Resistance Mapping Workflows
         GBS_RES(read_pairs_ch)
@@ -135,7 +135,7 @@ workflow {
         }
 
         // Once GBS or both resistance workflows are complete, trigger resistance typing
-        res_typer(id_ch, tmp_dir)
+        res_typer(id_ch, tmp_dir, params.restyper_min_read_depth)
 
         // Combine serotype and resistance type results for each sample
         sero_res_ch = serotyping.out.join(res_typer.out)

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -23,13 +23,15 @@ def printHelp() {
 
     Parameters:
       --gbs_res_min_coverage        Minimum coverage for mapping to the GBS resistance database. (Default: 99.9)
-      --gbs_res_max_divergence      Maximum divergence for mapping to the GBS resistance database. (Default: 5)
+      --gbs_res_max_divergence      Maximum divergence for mapping to the GBS resistance database. (Default: 5,
+                                    i.e. report only hits with <5% divergence)
       --other_res_min_coverage      Minimum coverage for mapping to other resistance reference database(s).
                                     Number of values must equal the number of resistance reference database files
                                     and must correspond to the order specified in --other_res_dbs. (Default: 70)
       --other_res_max_divergence    Maximum divergence for mapping to other resistance reference database(s).
                                     Number of values must equal the number of resistance reference database files
-                                    and must correspond to the order specified in --other_res_dbs. (Default: 30)
+                                    and must correspond to the order specified in --other_res_dbs. (Default: 30,
+                                    i.e. report only hits with <30% divergence)
       --restyper_min_read_depth     Minimum read depth where mappings to antibiotic resistance genes with fewer
                                     reads are excluded. (Default: 30)
       --serotyper_min_read_depth    Minimum read depth where mappings to serotyping genes with fewer reads are excluded.

--- a/modules/res_typer.nf
+++ b/modules/res_typer.nf
@@ -3,12 +3,13 @@ process res_typer {
     input:
     val(pair_id) // ID
     path(res_dir) // Directory of resistance mapping results
+    val(min_read_depth) // Minimum read depth threshold
 
     output:
     tuple val(pair_id), file("${pair_id}_res_incidence.txt"), file("${pair_id}_res_alleles_variants.txt"), file("${pair_id}_res_gbs_variants.txt")
 
     """
-    process_res_typer_results.py --srst2_gbs_fullgenes ${res_dir}/${pair_id}/${pair_id}_GBS_RES_*__fullgenes__*__results.txt --srst2_gbs_consensus ${res_dir}/${pair_id}/${pair_id}_consensus_seq.fna --srst2_other_fullgenes ${res_dir}/${pair_id}/${pair_id}_OTHER_RES_*__fullgenes__*__results.txt --min_read_depth ${params.restyper_min_read_depth} --output_prefix ${pair_id}
+    process_res_typer_results.py --srst2_gbs_fullgenes ${res_dir}/${pair_id}/${pair_id}_GBS_RES_*__fullgenes__*__results.txt --srst2_gbs_consensus ${res_dir}/${pair_id}/${pair_id}_consensus_seq.fna --srst2_other_fullgenes ${res_dir}/${pair_id}/${pair_id}_OTHER_RES_*__fullgenes__*__results.txt --min_read_depth ${min_read_depth} --output_prefix ${pair_id}
     rm ${res_dir}/${pair_id}/${pair_id}*
     """
 }

--- a/modules/serotyping.nf
+++ b/modules/serotyping.nf
@@ -3,6 +3,7 @@ process serotyping {
     input:
     tuple val(pair_id), file(reads) // ID and paired read files
     file(sero_gene_db) // Serotyping reference database
+    val(min_read_depth) // Minimum read depth threshold
 
     output:
     tuple val(pair_id), file("${pair_id}_SeroType_Results.txt")
@@ -11,6 +12,6 @@ process serotyping {
     # Changed TEMP_SeroType_Results.txt to ${pair_id}_SeroType_Results.txt
     # in GBS_Serotyper.pl so output channel can pick it up
     srst2 --samtools_args '\\-A' --input_pe ${reads[0]} ${reads[1]} --output SERO_${pair_id} --log --save_scores --min_coverage 99.0 --max_divergence 7 --gene_db ${sero_gene_db}
-    process_serotyper_results.py --srst2_output SERO_${pair_id} --sero_db ${sero_gene_db} --output ${pair_id}_SeroType_Results.txt --min_read_depth ${params.serotyper_min_read_depth}
+    process_serotyper_results.py --srst2_output SERO_${pair_id} --sero_db ${sero_gene_db} --output ${pair_id}_SeroType_Results.txt --min_read_depth ${min_read_depth}
     """
 }

--- a/tests/process_res_typer_results_test.py
+++ b/tests/process_res_typer_results_test.py
@@ -809,12 +809,12 @@ class TestProcessResTyperResults(unittest.TestCase):
         actual = get_arguments().parse_args(
             ['--srst2_gbs_fullgenes', 'srst2_gbs_fullgenes', '--srst2_gbs_consensus', 'srst2_gbs_consensus',
             '--srst2_other_fullgenes', 'srst2_argannot_fullgenes', 'srst2_resfinder_fullgenes',
-            '--min_read_depth', '30', '--output_prefix', 'output'])
+            '--min_read_depth', '30.0', '--output_prefix', 'output'])
         self.assertEqual(actual,
                          argparse.Namespace(srst2_gbs_fg_output='srst2_gbs_fullgenes',
                                             srst2_gbs_cs_output='srst2_gbs_consensus',
                                             srst2_other_fg_output=['srst2_argannot_fullgenes','srst2_resfinder_fullgenes'],
-                                            min_depth = 30,
+                                            min_depth = 30.0,
                                             output='output'))
 
     @patch('bin.process_res_typer_results.get_arguments')

--- a/tests/process_serotyper_results_test.py
+++ b/tests/process_serotyper_results_test.py
@@ -29,16 +29,16 @@ class TestProcessResults(unittest.TestCase):
         return "".join(self.test_stream.readlines())
 
     def test_arguments(self):
-        actual = get_arguments().parse_args(['--srst2_output', 'srst2_output_name', '--sero_db', 'sero_db', '--output', 'outfile', '--min_read_depth', '10'])
+        actual = get_arguments().parse_args(['--srst2_output', 'srst2_output_name', '--sero_db', 'sero_db', '--output', 'outfile', '--min_read_depth', '30.0'])
         self.assertEqual(actual,
-                         argparse.Namespace(id='srst2_output_name', db='sero_db', output='outfile', depth=10))
+                         argparse.Namespace(id='srst2_output_name', db='sero_db', output='outfile', depth=30.0))
 
     def test_arguments_short_options(self):
-        actual = get_arguments().parse_args(['-s', 'srst2_output_name', '-b', 'sero_db', '-o', 'outfile', '-d', '10'])
+        actual = get_arguments().parse_args(['-s', 'srst2_output_name', '-b', 'sero_db', '-o', 'outfile', '-d', '30.0'])
         self.assertEqual(actual,
-                         argparse.Namespace(id='srst2_output_name', db='sero_db', output='outfile', depth=10))
+                         argparse.Namespace(id='srst2_output_name', db='sero_db', output='outfile', depth=30.0))
 
     def test_arguments_without_depth_threshold(self):
         actual = get_arguments().parse_args(['-s', 'srst2_output_name', '-b', 'sero_db', '-o', 'outfile'])
         self.assertEqual(actual,
-                        argparse.Namespace(id='srst2_output_name', db='sero_db', output='outfile', depth=10))
+                        argparse.Namespace(id='srst2_output_name', db='sero_db', output='outfile', depth=30.0))


### PR DESCRIPTION
Added checking whether values of options are within range and removing some hardcoded paramters out of module files. 

I checked whether -resume prevents nextflow from rerunning again if output files exist, but it still runs from the last process and overwrites files. I can't see any obvious alternatives within Nextflow. My feeling is that we leave this for now. As a user I would always assume the files would be overwritten, but would obviously have to think about this if for whatever reason it gets integrated in pathpipe.